### PR TITLE
feat: 添加 main 分支自动构建 release 的工作流

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,29 @@
+name: Build Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Package release
+        run: node scripts/package-release.mjs
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: xpath-helper-plus-release
+          path: release/

--- a/scripts/package-release.mjs
+++ b/scripts/package-release.mjs
@@ -1,0 +1,20 @@
+import { readFileSync, cpSync, mkdirSync, existsSync } from "fs"
+import { execSync } from "child_process"
+import { join, dirname } from "path"
+import { fileURLToPath } from "url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = join(__dirname, "..")
+
+const { version, name } = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"))
+const releaseDir = join(root, "release")
+const archiveName = `${name}-v${version}.zip`
+
+if (!existsSync(releaseDir)) mkdirSync(releaseDir, { recursive: true })
+
+execSync(
+  `cd dist && zip -r "${join(releaseDir, archiveName)}" .`,
+  { cwd: root, stdio: "inherit" },
+)
+
+console.log(`Created ${join(releaseDir, archiveName)}`)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Xpath Helper Plus",
-    "version": "1.0.4",
+    "version": "1.0.7",
     "description": "Xpath Helper Plus",
     "manifest_version": 3,
     "action": {


### PR DESCRIPTION
## Summary

- 新增 GitHub Actions 工作流，当 push 到 `main` 分支或手动触发时自动构建并打包 release 产物
- 新增 `scripts/package-release.mjs` 打包脚本
- 修复 `src/manifest.json` 版本号与 `package.json` 同步为 `1.0.7`

## Test plan

- [x] CI 构建会自动在 push 到 main 时触发
- [x] 手动可通过 workflow_dispatch 触发
- [x] 构建产物会作为 artifact 上传