### PR TITLE
fix: restore popup entry and guard extension messaging

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,7 @@
-chrome.action.onClicked.addListener(tab => {
-    chrome.tabs.sendMessage(<number>tab.id, {cmd: 'toggleBar'}, () => {})
+import { sendMessageToContentScript } from './utils'
+
+chrome.action.onClicked.addListener(() => {
+  sendMessageToContentScript({ cmd: 'toggleBar' })
 })
 
 export {}

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -15,7 +15,7 @@ function handleMouseMove(e: any) {
   if (e.shiftKey) {
     clearHighlights()
     const query = currentEl ? makeQueryForElement(currentEl, xpathShort, xpathBatch) : ''
-    sendMessageToPopup({ type: 'query', query })
+    sendMessageToPopup({ query })
   }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,6 +4,7 @@
     "description": "Xpath Helper Plus",
     "manifest_version": 3,
     "action": {
+      "default_popup": "index.html",
       "default_icon": {
         "16": "assets/icon16.png",
         "24": "assets/icon24.png",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,30 @@
-import type { PopupMessage, SendResponseCallback } from '@/types/messages'
+import type { ContentScriptMessage, PopupMessage, SendResponseCallback } from '@/types/messages'
+
+function hasRuntimeConnectionError(): boolean {
+  const message = chrome.runtime.lastError?.message ?? ''
+  return message.includes('Could not establish connection') || message.includes('Receiving end does not exist')
+}
 
 export function sendMessageToContentScript(message: PopupMessage, callback?: SendResponseCallback): void {
   if (chrome?.tabs === undefined) return
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    chrome.tabs.sendMessage(<number>tabs[0].id, message, function (response) {
+    const activeTabId = tabs[0]?.id
+    if (activeTabId === undefined) {
+      callback?.()
+      return
+    }
+
+    chrome.tabs.sendMessage(activeTabId, message, function (response) {
+      if (chrome.runtime.lastError && hasRuntimeConnectionError()) {
+        callback?.()
+        return
+      }
+
       if (callback) callback(response)
     })
   })
 }
 
-export function sendMessageToPopup(message: Record<string, unknown>): void {
-  chrome.runtime.sendMessage(message).then(() => {})
+export function sendMessageToPopup(message: ContentScriptMessage): void {
+  chrome.runtime.sendMessage(message).catch(() => {})
 }

--- a/tests/e2e/manifest.spec.ts
+++ b/tests/e2e/manifest.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+test('manifest declares the popup entrypoint', async () => {
+  const manifestPath = path.resolve(__dirname, '../../src/manifest.json')
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+  expect(manifest.action.default_popup).toBe('index.html')
+})


### PR DESCRIPTION
## Summary
- restore the extension popup entry by adding `action.default_popup`
- guard popup/content-script messaging so missing receivers do not spam `runtime.lastError`
- add a regression test that asserts the popup entry remains declared in the manifest

## Verification
- `npm run typecheck`
- `npm run build`
- `npm run test:e2e`
